### PR TITLE
Drop table on each run

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -100,5 +100,5 @@ end
 grn = noko_for('http://www.hellenicparliament.gr/el/Vouleftes/Diatelesantes-Vouleftes-Apo-Ti-Metapolitefsi-Os-Simera/')
 @gr_names = Hash[grn.css('#ctl00_ContentPlaceHolder1_dmps_mpsListId option').map { |o| [o.attr('value'), o.text] }]
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 scrape_list('http://www.hellenicparliament.gr/en/Vouleftes/Diatelesantes-Vouleftes-Apo-Ti-Metapolitefsi-Os-Simera/')


### PR DESCRIPTION
56e19a665fda930f47f69514da84cd8a832d5bf3 changed the unique index key but we also need to make sure we drop the table from the db before each run because the table index is created when the table is created.

Part of: https://github.com/everypolitician/everypolitician/issues/593

> _SqliteMagic creates a unique index at CREATE TABLE time. (https://github.com/openc/sqlite_magic/blob/master/lib/sqlite_magic.rb#L42)_
> _This means that if the unique index arguments of ScraperWiki.save_sqlite, we need to create a new table to ensure the db reflects the change._